### PR TITLE
Add support for higher-order spherical harmonics (0-3rd order)

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -5,18 +5,77 @@ from plyfile import PlyData
 import numpy as np
 import argparse
 from io import BytesIO
+import os
+import struct
 
 
-def process_ply_to_splat(ply_file_path):
+def process_ply_to_splat(ply_file_path, sh_order=0):
+    """
+    Convert a PLY file to SPLAT format with support for higher-order spherical harmonics.
+    
+    Args:
+        ply_file_path: Path to the PLY file
+        sh_order: Spherical harmonics order (0, 1, 2, or 3)
+    
+    Returns:
+        Tuple of (splat_data, sh_data, max_sh_order)
+    """
     plydata = PlyData.read(ply_file_path)
     vert = plydata["vertex"]
+    
+    # Sort gaussians by size and opacity for better rendering
     sorted_indices = np.argsort(
         -np.exp(vert["scale_0"] + vert["scale_1"] + vert["scale_2"])
         / (1 + np.exp(-vert["opacity"]))
     )
+    
+    # Main buffer for position, scale, color, and rotation
     buffer = BytesIO()
+    
+    # Buffer for SH coefficients
+    sh_buffer = BytesIO()
+    
+    # Determine the actual max SH order available in the PLY file
+    max_sh_order = 0
+    sh_prefixes = {
+        0: ["f_dc_"],
+        1: ["f_dc_", "f_rest_"],
+        2: ["f_dc_", "f_rest_"],
+        3: ["f_dc_", "f_rest_"]
+    }
+    
+    # Check which SH coefficients are available in the PLY file
+    property_names = [p.name for p in vert.properties]
+    
+    # Count SH coefficients to determine the actual order
+    sh_count = 0
+    for name in property_names:
+        if name.startswith("f_dc_") or name.startswith("f_rest_"):
+            sh_count += 1
+    
+    # Calculate the actual max SH order based on coefficient count
+    # SH coefficients per order: 0th=3, 1st=3+9=12, 2nd=3+9+15=27, 3rd=3+9+15+21=48
+    if sh_count >= 48:
+        max_sh_order = 3
+    elif sh_count >= 27:
+        max_sh_order = 2
+    elif sh_count >= 12:
+        max_sh_order = 1
+    elif sh_count >= 3:
+        max_sh_order = 0
+    
+    # Use the minimum of requested and available SH order
+    effective_sh_order = min(sh_order, max_sh_order)
+    print(f"Using SH order: {effective_sh_order} (max available: {max_sh_order})")
+    
+    # SH coefficient constants
+    SH_C0 = 0.28209479177387814
+    
+    # Process each vertex
     for idx in sorted_indices:
         v = plydata["vertex"][idx]
+        
+        # Position, scale, rotation
         position = np.array([v["x"], v["y"], v["z"]], dtype=np.float32)
         scales = np.exp(
             np.array(
@@ -28,7 +87,8 @@ def process_ply_to_splat(ply_file_path):
             [v["rot_0"], v["rot_1"], v["rot_2"], v["rot_3"]],
             dtype=np.float32,
         )
-        SH_C0 = 0.28209479177387814
+        
+        # Basic color and opacity (for backward compatibility)
         color = np.array(
             [
                 0.5 + SH_C0 * v["f_dc_0"],
@@ -37,6 +97,8 @@ def process_ply_to_splat(ply_file_path):
                 1 / (1 + np.exp(-v["opacity"])),
             ]
         )
+        
+        # Write to main buffer
         buffer.write(position.tobytes())
         buffer.write(scales.tobytes())
         buffer.write((color * 255).clip(0, 255).astype(np.uint8).tobytes())
@@ -46,31 +108,131 @@ def process_ply_to_splat(ply_file_path):
             .astype(np.uint8)
             .tobytes()
         )
+        
+        # Process SH coefficients if needed
+        if effective_sh_order >= 0:
+            # 0th order (DC)
+            sh_0 = np.array([v["f_dc_0"], v["f_dc_1"], v["f_dc_2"]], dtype=np.float32)
+            # Convert to 16-bit signed integers (-32768 to 32767)
+            sh_0_int = np.int16((sh_0 * 32768).clip(-32768, 32767))
+            # Pack as two uint32 values (RGB)
+            sh_0_packed = np.array([
+                (int(sh_0_int[0]) & 0xFFFF) | ((int(sh_0_int[1]) & 0xFFFF) << 16),
+                (int(sh_0_int[2]) & 0xFFFF) | (0 << 16),
+                0,
+                0
+            ], dtype=np.uint32)
+            sh_buffer.write(sh_0_packed.tobytes())
+            
+            # Higher order coefficients
+            if effective_sh_order >= 1:
+                # 1st order (3 coefficients, each with RGB)
+                for i in range(3):
+                    base_idx = i * 3
+                    sh_coeff = np.array([
+                        v.get(f"f_rest_{base_idx+0}", 0.0),
+                        v.get(f"f_rest_{base_idx+1}", 0.0),
+                        v.get(f"f_rest_{base_idx+2}", 0.0)
+                    ], dtype=np.float32)
+                    
+                    sh_coeff_int = np.int16((sh_coeff * 32768).clip(-32768, 32767))
+                    sh_coeff_packed = np.array([
+                        (int(sh_coeff_int[0]) & 0xFFFF) | ((int(sh_coeff_int[1]) & 0xFFFF) << 16),
+                        (int(sh_coeff_int[2]) & 0xFFFF) | (0 << 16),
+                        0,
+                        0
+                    ], dtype=np.uint32)
+                    sh_buffer.write(sh_coeff_packed.tobytes())
+                
+                if effective_sh_order >= 2:
+                    # 2nd order (5 coefficients, each with RGB)
+                    for i in range(5):
+                        base_idx = 9 + i * 3  # After the 1st order coefficients
+                        sh_coeff = np.array([
+                            v.get(f"f_rest_{base_idx+0}", 0.0),
+                            v.get(f"f_rest_{base_idx+1}", 0.0),
+                            v.get(f"f_rest_{base_idx+2}", 0.0)
+                        ], dtype=np.float32)
+                        
+                        sh_coeff_int = np.int16((sh_coeff * 32768).clip(-32768, 32767))
+                        sh_coeff_packed = np.array([
+                            (int(sh_coeff_int[0]) & 0xFFFF) | ((int(sh_coeff_int[1]) & 0xFFFF) << 16),
+                            (int(sh_coeff_int[2]) & 0xFFFF) | (0 << 16),
+                            0,
+                            0
+                        ], dtype=np.uint32)
+                        sh_buffer.write(sh_coeff_packed.tobytes())
+                    
+                    if effective_sh_order >= 3:
+                        # 3rd order (7 coefficients, each with RGB)
+                        for i in range(7):
+                            base_idx = 9 + 15 + i * 3  # After 1st and 2nd order coefficients
+                            sh_coeff = np.array([
+                                v.get(f"f_rest_{base_idx+0}", 0.0),
+                                v.get(f"f_rest_{base_idx+1}", 0.0),
+                                v.get(f"f_rest_{base_idx+2}", 0.0)
+                            ], dtype=np.float32)
+                            
+                            sh_coeff_int = np.int16((sh_coeff * 32768).clip(-32768, 32767))
+                            sh_coeff_packed = np.array([
+                                (int(sh_coeff_int[0]) & 0xFFFF) | ((int(sh_coeff_int[1]) & 0xFFFF) << 16),
+                                (int(sh_coeff_int[2]) & 0xFFFF) | (0 << 16),
+                                0,
+                                0
+                            ], dtype=np.uint32)
+                            sh_buffer.write(sh_coeff_packed.tobytes())
 
-    return buffer.getvalue()
+    return buffer.getvalue(), sh_buffer.getvalue(), effective_sh_order
 
 
-def save_splat_file(splat_data, output_path):
+def save_splat_files(splat_data, sh_data, sh_order, output_path):
+    """
+    Save the SPLAT and SH data to files.
+    
+    Args:
+        splat_data: Main SPLAT data
+        sh_data: SH coefficient data
+        sh_order: SH order used
+        output_path: Base path for output files
+    """
+    # Save main SPLAT file
     with open(output_path, "wb") as f:
         f.write(splat_data)
+    
+    # Save SH data if available
+    if sh_order >= 0 and len(sh_data) > 0:
+        sh_path = os.path.splitext(output_path)[0] + ".sh"
+        with open(sh_path, "wb") as f:
+            # Write header with SH order
+            f.write(struct.pack('i', sh_order))
+            # Write SH data
+            f.write(sh_data)
+        print(f"Saved SH data to {sh_path} (order {sh_order})")
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Convert PLY files to SPLAT format.")
+    parser = argparse.ArgumentParser(description="Convert PLY files to SPLAT format with SH support.")
     parser.add_argument(
         "input_files", nargs="+", help="The input PLY files to process."
     )
     parser.add_argument(
         "--output", "-o", default="output.splat", help="The output SPLAT file."
     )
+    parser.add_argument(
+        "--sh_order", "-s", type=int, default=0, choices=[0, 1, 2, 3],
+        help="Spherical harmonics order (0-3, default: 0)"
+    )
     args = parser.parse_args()
+    
     for input_file in args.input_files:
         print(f"Processing {input_file}...")
-        splat_data = process_ply_to_splat(input_file)
+        splat_data, sh_data, effective_sh_order = process_ply_to_splat(input_file, args.sh_order)
+        
         output_file = (
             args.output if len(args.input_files) == 1 else input_file + ".splat"
         )
-        save_splat_file(splat_data, output_file)
+        
+        save_splat_files(splat_data, sh_data, effective_sh_order, output_file)
         print(f"Saved {output_file}")
 
 

--- a/index.html
+++ b/index.html
@@ -1,209 +1,208 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
-	<head>
-		<title>WebGL Gaussian Splat Viewer</title>
-		<meta charset="utf-8" />
-		<meta
-			name="viewport"
-			content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no"
-		/>
-		<meta name="apple-mobile-web-app-capable" content="yes" />
-		<meta
-			name="apple-mobile-web-app-status-bar-style"
-			content="black-translucent"
-		/>
-		<style>
-			body {
-				overflow: hidden;
-				margin: 0;
-				height: 100vh;
-				width: 100vw;
-				font-family: sans-serif;
-				background: black;
-    			text-shadow: 0 0 3px black;
-			}
-			a, body {
-				color: white;
-			}
-			#info {
-				z-index: 100;
-				position: absolute;
-				top: 10px;
-				left: 15px;
-			}
-			h3 {
-				margin: 5px 0;
-			}
-			p {
-				margin: 5px 0;
-				font-size: small;
-			}
+<head>
+<title>WebGL Gaussian Splat Viewer</title>
+<meta charset="utf-8" />
+<meta
+name="viewport"
+content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no"
+/>
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta
+name="apple-mobile-web-app-status-bar-style"
+content="black-translucent"
+/>
+<style>
+body {
+overflow: hidden;
+margin: 0;
+height: 100vh;
+width: 100vw;
+font-family: sans-serif;
+background: black;
+    text-shadow: 0 0 3px black;
+}
+a, body {
+color: white;
+}
+#info {
+z-index: 100;
+position: absolute;
+top: 10px;
+left: 15px;
+}
+h3 {
+margin: 5px 0;
+}
+p {
+margin: 5px 0;
+font-size: small;
+}
 
-			.cube-wrapper {
-				transform-style: preserve-3d;
-			}
+.cube-wrapper {
+transform-style: preserve-3d;
+}
 
-			.cube {
-				transform-style: preserve-3d;
-				transform: rotateX(45deg) rotateZ(45deg);
-				animation: rotation 2s infinite;
-			}
+.cube {
+transform-style: preserve-3d;
+transform: rotateX(45deg) rotateZ(45deg);
+animation: rotation 2s infinite;
+}
 
-			.cube-faces {
-				transform-style: preserve-3d;
-				height: 80px;
-				width: 80px;
-				position: relative;
-				transform-origin: 0 0;
-				transform: translateX(0) translateY(0) translateZ(-40px);
-			}
+.cube-face {
+position: absolute;
+width: 20px;
+height: 20px;
+background: blue;
+}
 
-			.cube-face {
-				position: absolute;
-				inset: 0;
-				background: #0017ff;
-				border: solid 1px #ffffff;
-			}
-			.cube-face.top {
-				transform: translateZ(80px);
-			}
-			.cube-face.front {
-				transform-origin: 0 50%;
-				transform: rotateY(-90deg);
-			}
-			.cube-face.back {
-				transform-origin: 0 50%;
-				transform: rotateY(-90deg) translateZ(-80px);
-			}
-			.cube-face.right {
-				transform-origin: 50% 0;
-				transform: rotateX(-90deg) translateY(-80px);
-			}
-			.cube-face.left {
-				transform-origin: 50% 0;
-				transform: rotateX(-90deg) translateY(-80px) translateZ(80px);
-			}
+#spinner {
+position: absolute;
+top: 50%;
+left: 50%;
+margin-top: -10px;
+margin-left: -10px;
+}
 
-			@keyframes rotation {
-				0% {
-					transform: rotateX(45deg) rotateY(0) rotateZ(45deg);
-					animation-timing-function: cubic-bezier(
-						0.17,
-						0.84,
-						0.44,
-						1
-					);
-				}
-				50% {
-					transform: rotateX(45deg) rotateY(0) rotateZ(225deg);
-					animation-timing-function: cubic-bezier(
-						0.76,
-						0.05,
-						0.86,
-						0.06
-					);
-				}
-				100% {
-					transform: rotateX(45deg) rotateY(0) rotateZ(405deg);
-					animation-timing-function: cubic-bezier(
-						0.17,
-						0.84,
-						0.44,
-						1
-					);
-				}
-			}
+.cube-face:nth-child(1) {
+transform: translateZ(10px);
+}
+.cube-face:nth-child(2) {
+transform: rotateY(180deg) translateZ(10px);
+}
+.cube-face:nth-child(3) {
+transform: rotateY(90deg) translateZ(10px);
+}
+.cube-face:nth-child(4) {
+transform: rotateY(-90deg) translateZ(10px);
+}
+.cube-face:nth-child(5) {
+transform: rotateX(90deg) translateZ(10px);
+}
+.cube-face:nth-child(6) {
+transform: rotateX(-90deg) translateZ(10px);
+}
 
-			.scene,
-			#message {
-				position: absolute;
-				display: flex;
-				top: 0;
-				right: 0;
-				left: 0;
-				bottom: 0;
-				z-index: 2;
-				height: 100%;
-				width: 100%;
-				align-items: center;
-				justify-content: center;
-			}
-			#message {
-				font-weight: bold;
-				font-size: large;
-				color: red;
-				pointer-events: none;
-			}
+@keyframes rotation {
+0% {
+transform: rotateX(45deg) rotateY(0) rotateZ(45deg);
+animation-timing-function: cubic-bezier(
+0.17,
+0.84,
+0.44,
+1
+);
+}
+50% {
+transform: rotateX(45deg) rotateY(0) rotateZ(225deg);
+animation-timing-function: cubic-bezier(
+0.76,
+0.05,
+0.86,
+0.06
+);
+}
+100% {
+transform: rotateX(45deg) rotateY(0) rotateZ(405deg);
+animation-timing-function: cubic-bezier(
+0.17,
+0.84,
+0.44,
+1
+);
+}
+}
 
-			details {
-				font-size: small;
+.scene,
+#message {
+position: absolute;
+display: flex;
+top: 0;
+right: 0;
+left: 0;
+bottom: 0;
+z-index: 2;
+height: 100%;
+width: 100%;
+align-items: center;
+justify-content: center;
+}
+#message {
+font-weight: bold;
+font-size: large;
+color: red;
+pointer-events: none;
+}
 
-			}
+details {
+font-size: small;
 
-			#progress {
-				position: absolute;
-				top: 0;
-				height: 5px;
-				background: blue;
-				z-index: 99;
-				transition: width 0.1s ease-in-out;
-			}
+}
 
-			#quality {
-				position: absolute;
-				bottom: 10px;
-				z-index: 999;
-				right: 10px;
-			}
+#progress {
+position: absolute;
+top: 0;
+height: 5px;
+background: blue;
+z-index: 99;
+transition: width 0.1s ease-in-out;
+}
 
-			#caminfo {
-				position: absolute;
-				top: 10px;
-				z-index: 999;
-				right: 10px;
-			}
-			#canvas {
-				display: block;
-				position: absolute;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height: 100%;
-				touch-action: none;
-			}
+#quality {
+position: absolute;
+bottom: 10px;
+z-index: 999;
+right: 10px;
+}
 
-			#instructions {
-				background: rgba(0,0,0,0.6);
-				white-space: pre-wrap;
-				padding: 10px;
-				border-radius: 10px;
-				font-size: x-small;
-			}
-			body.nohf .nohf {
-				display: none;
-			}
-			body.nohf #progress, body.nohf .cube-face {
-				background: #ff9d0d;
-			}
-		</style>
-	</head>
-	<body>
-		<script>
-			if(location.host.includes('hf.space')) document.body.classList.add('nohf');
-		</script>
-		<div id="info">
-			<h3 class="nohf">WebGL 3D Gaussian Splat Viewer</h3>
-			<p>
-			<small class="nohf">
-				By <a href="https://twitter.com/antimatter15">Kevin Kwok</a>.
-				Code on
-				<a href="https://github.com/antimatter15/splat">Github</a
-				>.
-			</small>
-		</p>
+#caminfo {
+position: absolute;
+top: 10px;
+z-index: 999;
+right: 10px;
+}
+#canvas {
+display: block;
+position: absolute;
+top: 0;
+left: 0;
+width: 100%;
+height: 100%;
+touch-action: none;
+}
 
-			<details>
-			<summary>Use mouse or arrow keys to navigate.</summary>
+#instructions {
+background: rgba(0,0,0,0.6);
+white-space: pre-wrap;
+padding: 10px;
+border-radius: 10px;
+font-size: x-small;
+}
+body.nohf .nohf {
+display: none;
+}
+body.nohf #progress, body.nohf .cube-face {
+background: #ff9d0d;
+}
+</style>
+</head>
+<body>
+<script>
+if(location.host.includes('hf.space')) document.body.classList.add('nohf');
+</script>
+<div id="info">
+<h3 class="nohf">WebGL 3D Gaussian Splat Viewer</h3>
+<p>
+<small class="nohf">
+By <a href="https://twitter.com/antimatter15">Kevin Kwok</a>.
+Code on
+<a href="https://github.com/antimatter15/splat">Github</a
+>.
+</small>
+</p>
+
+<details>
+<summary>Use mouse or arrow keys to navigate.</summary>
 
 <div id="instructions">movement (arrow keys)
 - left/right arrow keys to strafe side to side
@@ -243,35 +242,40 @@ other
 - drag and drop cameras.json to load cameras
 </div>
 
-		</details>
-			
-		</div>
+</details>
 
-		<div id="progress"></div>
+</div>
 
-		<div id="message"></div>
-		<div class="scene" id="spinner">
-			<div class="cube-wrapper">
-				<div class="cube">
-					<div class="cube-faces">
-						<div class="cube-face bottom"></div>
-						<div class="cube-face top"></div>
-						<div class="cube-face left"></div>
-						<div class="cube-face right"></div>
-						<div class="cube-face back"></div>
-						<div class="cube-face front"></div>
-					</div>
-				</div>
-			</div>
-		</div>
-		<canvas id="canvas"></canvas>
+<div id="progress"></div>
+<div id="message"></div>
+<div id="spinner" class="scene">
+<div class="cube-wrapper">
+<div class="cube">
+<div class="cube-face"></div>
+<div class="cube-face"></div>
+<div class="cube-face"></div>
+<div class="cube-face"></div>
+<div class="cube-face"></div>
+<div class="cube-face"></div>
+</div>
+</div>
+</div>
+<canvas id="canvas"></canvas>
 
-		<div id="quality">
-			<span id="fps"></span>
-		</div>
-		<div id="caminfo">
-			<span id="camid"></span>
-		</div>
-		<script src="main.js"></script>
-	</body>
+<div id="quality">
+<span id="fps"></span>
+<div style="margin-top: 5px;">
+<select id="sh-order-select">
+<option value="0">SH Order 0</option>
+<option value="1">SH Order 1</option>
+<option value="2">SH Order 2</option>
+<option value="3">SH Order 3</option>
+</select>
+</div>
+</div>
+<div id="caminfo">
+<span id="camid"></span>
+</div>
+<script src="main.js"></script>
+</body>
 </html>


### PR DESCRIPTION
This PR adds support for higher-order spherical harmonics (0-3rd order) to the WebGL 3D Gaussian Splatting renderer.

## Changes:

- Added SH evaluation function to fragment shader based on "Efficient Spherical Harmonic Evaluation"
- Modified vertex shader to pass SH coefficients to fragment shader
- Updated conversion script to extract and process SH coefficients up to 3rd order
- Added SH texture creation and binding in WebGL
- Added SH order uniform to shaders
- Added SH data file loading logic
- Added camera position uniform update for view-dependent lighting
- Added UI element for SH order selection in index.html
- Added backward compatibility for lower SH orders

## Testing:

Tested with different SH orders (0-3) using the UI dropdown selector.